### PR TITLE
Use tasks, not settings, to invoke brew lazily

### DIFF
--- a/sbt-plugin/src/main/scala/com/armanbilge/sbt/ScalaNativeBrewedConfigPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/armanbilge/sbt/ScalaNativeBrewedConfigPlugin.scala
@@ -60,8 +60,8 @@ object ScalaNativeBrewedConfigPlugin extends AutoPlugin {
     )
 
   private lazy val brewNativeConfig =
-    Def.setting[BrewNativeConfig](BrewNativeConfig(brew.value, nativeBrewFormulas.value.toList))
+    Def.task[BrewNativeConfig](BrewNativeConfig(brew.value, nativeBrewFormulas.value.toList))
 
-  private lazy val brew = Def.setting[Brew](nativeBrew.value.fold(Brew())(Brew(_)))
+  private lazy val brew = Def.task[Brew](nativeBrew.value.fold(Brew())(Brew(_)))
 
 }

--- a/sbt-plugin/src/sbt-test/brewed-config/uninstalled/build.sbt
+++ b/sbt-plugin/src/sbt-test/brewed-config/uninstalled/build.sbt
@@ -1,0 +1,2 @@
+enablePlugins(ScalaNativeBrewedConfigPlugin)
+nativeBrewFormulas += "is-not-installed"

--- a/sbt-plugin/src/sbt-test/brewed-config/uninstalled/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/brewed-config/uninstalled/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.armanbilge" % "sbt-scala-native-config-brew" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/brewed-config/uninstalled/test
+++ b/sbt-plugin/src/sbt-test/brewed-config/uninstalled/test
@@ -1,0 +1,1 @@
+# Just verify that we can load the build


### PR DESCRIPTION
If a user did not have brew or the required formulae installed, the build would completely fail to load. This fixes that by using tasks to only invoke brew lazily.