### PR TITLE
Soft failures: log warnings, but continue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The plugin has two additional requirements:
 1. brew is already installed in your system. Use the `nativeBrew` setting to point it at a non-default location.
 2. The desired formulae have already been installed. The plugin will not install them for you; it only configures Scala Native to use an existing installation.
 
+However, these are only soft requirements: if brew or the requested formula are not installed, the plugin will log a warning and not update any configuration. So it will not interfere with a user who does not have or want brew.
+
 Future releases may introduce capabilities to automatically install formulae and self-bootstrap without an existing brew installation. Please open an issue if these features are important to you.
 
 ### GitHub Actions

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The plugin has two additional requirements:
 1. brew is already installed in your system. Use the `nativeBrew` setting to point it at a non-default location.
 2. The desired formulae have already been installed. The plugin will not install them for you; it only configures Scala Native to use an existing installation.
 
-However, these are only soft requirements: if brew or the requested formula are not installed, the plugin will log a warning and not update any configuration. So it will not interfere with a user who does not have or want brew.
+However, these are only soft requirements: if brew or the requested formulae are not installed, the plugin will log a warning and not update any configuration. So it will not interfere with a user who does not have or want brew.
 
 Future releases may introduce capabilities to automatically install formulae and self-bootstrap without an existing brew installation. Please open an issue if these features are important to you.
 

--- a/sbt-plugin/src/main/scala/com/armanbilge/sbt/ScalaNativeBrewedConfigPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/armanbilge/sbt/ScalaNativeBrewedConfigPlugin.scala
@@ -62,7 +62,7 @@ object ScalaNativeBrewedConfigPlugin extends AutoPlugin {
             val formulas = nativeBrewFormulas.value.mkString(", ")
             log.warn(s"Cannot find brew-installed $formulas.")
             log.warn(
-              s"nativeCompileOptions and nativeLinkingOptions must be manually configured."
+              s"nativeCompileOptions and nativeLinkingOptions will not be auto-configured."
             )
             oldConfig
         }
@@ -78,7 +78,7 @@ object ScalaNativeBrewedConfigPlugin extends AutoPlugin {
           case Failure(_) =>
             val formulas = nativeBrewFormulas.value.mkString(", ")
             log.warn(s"Cannot find brew-installed $formulas.")
-            log.warn(s"LD_LIBRARY_PATH must be manually configured.")
+            log.warn(s"LD_LIBRARY_PATH will not be auto-configured.")
             oldEnv
         }
       }


### PR DESCRIPTION
A step further, this makes it possible to use the plugin with non-brewed dependencies. But then the responsibility falls to the user.