### PR TITLE
Update Scala Native to `0.4.17`, sbt-typelevel-github-actions to `0.7.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
+      - name: Install sbt
+        if: contains(runner.os, 'macos')
+        run: brew install sbt
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
@@ -41,7 +45,7 @@ jobs:
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 8
@@ -83,7 +87,7 @@ jobs:
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
           path: targets.tar
@@ -98,6 +102,10 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install sbt
+        if: contains(runner.os, 'macos')
+        run: brew install sbt
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
@@ -106,7 +114,7 @@ jobs:
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 8
@@ -117,7 +125,7 @@ jobs:
         run: sbt +update
 
       - name: Download target directories (2.12)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.12
 
@@ -159,6 +167,10 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install sbt
+        if: contains(runner.os, 'macos')
+        run: brew install sbt
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
@@ -167,7 +179,7 @@ jobs:
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 8

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ ThisBuild / githubWorkflowBuildPreamble += {
 val scala2_12 = "2.12.19"
 val scala2_13 = "2.13.13"
 val scala3 = "3.3.3"
-val scalaNativeVersion = "0.5.1"
+val scalaNativeVersion = "0.4.17"
 
 lazy val root = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -20,10 +20,10 @@ ThisBuild / githubWorkflowBuildPreamble += {
   )
 }
 
-val scala2_12 = "2.12.18"
-val scala2_13 = "2.13.12"
-val scala3 = "3.3.1"
-val scalaNativeVersion = "0.4.14"
+val scala2_12 = "2.12.19"
+val scala2_13 = "2.13.13"
+val scala3 = "3.3.3"
+val scalaNativeVersion = "0.5.1"
 
 lazy val root = project
   .in(file("."))
@@ -69,5 +69,5 @@ lazy val ghaPlugin = project
   .dependsOn(sbtPlugin)
   .settings(
     name := "sbt-scala-native-config-brew-github-actions",
-    addSbtPlugin("org.typelevel" % "sbt-typelevel-github-actions" % "0.6.2")
+    addSbtPlugin("org.typelevel" % "sbt-typelevel-github-actions" % "0.7.0")
   )

--- a/core/src/main/scala/com/armanbilge/scalanative/brew/Brew.scala
+++ b/core/src/main/scala/com/armanbilge/scalanative/brew/Brew.scala
@@ -21,7 +21,7 @@ import io.circe.jawn
 
 import java.nio.file.Path
 import java.nio.file.Paths
-import scala.scalanative.build.Platform
+import java.util.Locale
 import scala.sys.process._
 
 import Brew._
@@ -43,15 +43,18 @@ final class Brew private (bin: String) {
 object Brew {
 
   def apply(): Brew = {
+    val osUsed =
+      System.getProperty("os.name", "unknown").toLowerCase(Locale.ROOT)
+
     val bin =
-      if (Platform.isMac) {
+      if (osUsed.contains("mac")) {
         val isArm =
           Option(System.getProperty("os.arch")).exists(_.toLowerCase().contains("aarch64"))
         if (isArm)
           "/opt/homebrew/bin/brew"
         else
           "/usr/local/bin/brew"
-      } else if (Platform.isLinux) "/home/linuxbrew/.linuxbrew/bin/brew"
+      } else if (osUsed.contains("linux")) "/home/linuxbrew/.linuxbrew/bin/brew"
       else throw new RuntimeException("unsupported OS")
 
     apply(bin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.6.2")
-addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.1")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.10.0")

--- a/sbt-plugin/src/sbt-test/brewed-config/curl/build.sbt
+++ b/sbt-plugin/src/sbt-test/brewed-config/curl/build.sbt
@@ -1,5 +1,12 @@
 enablePlugins(ScalaNativeBrewedConfigPlugin)
 enablePlugins(ScalaNativeJUnitPlugin)
 nativeBrewFormulas += "curl"
-nativeLinkingOptions += "-lcrypto" // this tends to piss off macOS
+
+Compile / nativeConfig := {
+  val nc = nativeConfig.value
+  nc.withLinkingOptions(
+    nc.linkingOptions :+ "-lcrypto" // this tends to piss off macOS
+  )
+}
+
 testOptions += Tests.Argument("-a", "-s", "-v")


### PR DESCRIPTION
This plugin does not work with sbt-typelevel `0.7.0` out of the box. The error:
```
java.lang.InstantiationError: org.typelevel.sbt.gha.WorkflowStep$Run
	at com.armanbilge.sbt.ScalaNativeBrewedGithubActionsPlugin$.$anonfun$buildSettings$3(ScalaNativeBrewedGithubActionsPlugin.scala:59)
	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
	at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:[22](https://github.com/typelevel/otel4s/actions/runs/8832237965/job/24249155135?pr=645#step:4:23)9)
	at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:171)
	at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:88)
	at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:100)
	at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:95)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:6[24](https://github.com/typelevel/otel4s/actions/runs/8832237965/job/24249155135?pr=645#step:4:25))
	at java.lang.Thread.run(Thread.java:750)
```

Both Skunk and otel4s use this plugin to install native-specific dependencies: s2n, etc.